### PR TITLE
Add optional homepageurl command

### DIFF
--- a/mark_liu_resume.tex
+++ b/mark_liu_resume.tex
@@ -31,6 +31,7 @@
 \mobile{(omitted for web)}                    % optional, remove the line if not wanted
 \email{markwayneliu@gmail.com}                      % optional, remove the line if not wanted
 \homepage{http://markliu.me}                % optional, remove the line if not wanted
+\homepageurl{markliu.me}
 %\extrainfo{\url{http://markliu.me}} % optional, remove the line if not wanted
 
 % to show numerical labels in the bibliography; only useful if you make citations in your resume

--- a/moderncv/moderncv.cls
+++ b/moderncv/moderncv.cls
@@ -265,6 +265,7 @@
 \renewcommand*{\fax}[1]{\def\@fax{#1}}
 \newcommand*{\email}[1]{\def\@email{#1}}
 \newcommand*{\homepage}[1]{\def\@homepage{#1}}
+\newcommand*{\homepageurl}[1]{\def\@homepageurl{#1}}
 \newcommand*{\extrainfo}[1]{\def\@extrainfo{#1}}
 \def\@photowidth{0pt}
 \newcommand*{\photo}[2][64pt]{\def\@photowidth{#1}\def\@photo{#2}}

--- a/moderncv/moderncvthemecasual.sty
+++ b/moderncv/moderncvthemecasual.sty
@@ -141,7 +141,7 @@
       \ifthenelse{\isundefined{\@phone}}{}{\footersymbol\phonesymbol~\@phone\@firstfooterelementfalse}%
       \ifthenelse{\isundefined{\@fax}}{}{\footersymbol\faxsymbol~\@fax\@firstfooterelementfalse}%
       \ifthenelse{\isundefined{\@email}}{}{\footersymbol\emailsymbol~\emaillink{\@email}\@firstfooterelementfalse}%
-      \ifthenelse{\isundefined{\@homepage}}{}{\footersymbol\homepagesymbol~\httplink{\@homepage}\@firstfooterelementfalse}%
+      \ifthenelse{\isundefined{\@homepage}}{}{\ifthenelse{\isundefined{\@homepageurl}}{\footersymbol\homepagesymbol~\httplink{\@homepage}\@firstfooterelementfalse}{\footersymbol\homepagesymbol~\httplink{\@homepageurl}\@firstfooterelementfalse}}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\footersymbol\@extrainfo\@firstfooterelementfalse}}}%
   }%
   \pagestyle{plain}}

--- a/moderncv/moderncvthemeclassic.sty
+++ b/moderncv/moderncvthemeclassic.sty
@@ -148,7 +148,7 @@
     \ifthenelse{\isundefined{\@phone}}{}{\maketitledetailsnewline\phonesymbol~\@phone}%
     \ifthenelse{\isundefined{\@fax}}{}{\maketitledetailsnewline\faxsymbol~\@fax}%
     \ifthenelse{\isundefined{\@email}}{}{\maketitledetailsnewline\emailsymbol~\emaillink{\@email}}%
-    \ifthenelse{\isundefined{\@homepage}}{}{\maketitledetailsnewline\homepagesymbol~\httplink{\@homepage}}%
+    \ifthenelse{\isundefined{\@homepage}}{}{\ifthenelse{\isundefined{\@homepageurl}}{\maketitledetailsnewline\homepagesymbol~\httplink{\@homepage}}{\maketitledetailsnewline\homepagesymbol~\httplink{\@homepageurl}}}%
     \ifthenelse{\isundefined{\@extrainfo}}{}{\maketitledetailsnewline\@extrainfo}%
   \end{minipage}%
   % optional photo


### PR DESCRIPTION
\httplink uses the same argument (\homepage) for the displayed link and the URL, which results in
\homepage{http://markliu.me}
linking to
http://http://markliu.me
in the output PDF. This request adds an optional \homepageurl command to set the desired URL so that display links like "http://markliu.me" work.
